### PR TITLE
Also load .uc.js, .uc.xul files, and userChrome.xul

### DIFF
--- a/userChrome.xml
+++ b/userChrome.xml
@@ -12,14 +12,30 @@ https://opensource.org/licenses/MIT
   <binding id="js" extends="chrome://global/content/bindings/toolbarbutton.xml#menu">
     <implementation>
         <constructor><![CDATA[
-            function makeRelativePathURI(name) {
-              let absolutePath = Components.stack.filename;
-              return absolutePath.substring(0, absolutePath.lastIndexOf("/") + 1) + name;
-            }
-
-            // The following code executes in the browser context,
-            // i.e. chrome://browser/content/browser.xul
-            Services.scriptloader.loadSubScript(makeRelativePathURI("userChrome.js"), window);
+            var getURLSpecFromFile = Components.classes["@mozilla.org/network/io-service;1"].getService(Components.interfaces.nsIIOService).getProtocolHandler("file").QueryInterface(Components.interfaces.nsIFileProtocolHandler).getURLSpecFromFile;
+			var chromeDir = Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("UChrm", Components.interfaces.nsIFile);
+			var files = chromeDir.directoryEntries.QueryInterface(Components.interfaces.nsISimpleEnumerator);
+			var xul_files = [];
+			
+			while(files.hasMoreElements()) {
+				var file = files.getNext().QueryInterface(Components.interfaces.nsIFile);
+				
+				if(/(^userChrome|\.uc)\.js$/i.test(file.leafName)) {
+					setTimeout(function(aFile) {
+						Components.classes["@mozilla.org/moz/jssubscript-loader;1"].getService(Components.interfaces.mozIJSSubScriptLoader).loadSubScript(getURLSpecFromFile(aFile));
+					}, 0, file);
+				}
+				else if(/(^userChrome|\.uc)\.xul$/i.test(file.leafName)) {
+					xul_files.push(file);
+				}
+			}
+			
+			setTimeout(function() {
+				if(xul_files.length > 0) {
+					document.loadOverlay(getURLSpecFromFile(xul_files.shift()), null);
+					setTimeout(arguments.callee, 0);
+				}
+			}, 0);
         ]]></constructor>
     </implementation>
   </binding>


### PR DESCRIPTION
Instead of loading all scripts in one file, you can separate them to keep some order. Now you can just copy scripts from repositories like [this](https://github.com/Endor8/userChrome.js) to the chrome folder.

I got it from [here](http://mozilla.zeniko.ch/userchrome.js.html) (Sub-Script/XUL Loader), but made small changes to load userChrome.js as well (regex on line 23) and work with future Firefox versions (nsILocalFile > nsIFile on line 16). 